### PR TITLE
Added FileProvider for Android to the Manifest

### DIFF
--- a/config/Android/AndroidManifest.xml
+++ b/config/Android/AndroidManifest.xml
@@ -151,6 +151,15 @@
 					 android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize"/>
 			 
 			<receiver android:name="io.smartface.android.notifications.LocalNotificationReceiver"/>
-
+			
+			<provider
+				android:name="android.support.v4.content.FileProvider"
+				android:authorities="${PackageName}.provider"
+				android:exported="false"
+				android:grantUriPermissions="true">
+				<meta-data
+					android:name="android.support.FILE_PROVIDER_PATHS"
+					android:resource="@xml/provider_paths"/>
+			</provider>
 	</application>
 </manifest>


### PR DESCRIPTION
FileProvider added for Android build 23+ devices. When developer want to share file, he/she needs this file provider otherwise application will throw exception. 