### PR TITLE
Update Info.plist

### DIFF
--- a/config/iOS/Info.plist
+++ b/config/iOS/Info.plist
@@ -21,6 +21,10 @@
 	<string>Your NSAppleMusicUsageDescription</string>
 	<key>NSMotionUsageDescription</key>
 	<string>Your NSMotionUsageDescription</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Your NSMicrophoneUsageDescription</string>
+	<key>NSSpeechRecognitionUsageDescription </key>
+	<string>Your NSSpeechRecognitionUsageDescription </string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
Missing Info.plist key - This app attempts to access privacy-sensitive data without a usage description. The app's Info.plist must contain an NSMicrophoneUsageDescription key with a string value explaining to the user how the app uses this data.

Missing Info.plist key - This app attempts to access privacy-sensitive data without a usage description. The app's Info.plist must contain an NSSpeechRecognitionUsageDescription key with a string value explaining to the user how the app uses this data.
